### PR TITLE
add add to cart functionality to all page and single page

### DIFF
--- a/client/components/Items.js
+++ b/client/components/Items.js
@@ -1,16 +1,27 @@
-import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
-import { selectItems, fetchItems } from '../store/slices/items';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { selectItems, fetchItems, addItemToCart } from "../store/slices/items";
+import { useDispatch, useSelector } from "react-redux";
 
 const Items = () => {
+  const user = useSelector((state) => state.auth.user);
+  let userId = null;
+  if (user) {
+    userId = user.id;
+  }
+
   const dispatch = useDispatch();
-  let items = ITEM_SEED_DATA;
   useEffect(() => {
-    //dispatch(fetchItems());
+    dispatch(fetchItems());
   }, [dispatch]);
 
-  //const items = useSelector(selectItems);
+  let items = useSelector(selectItems);
+
+  const handleAddToCart = async (itemId) => {
+    await dispatch(addItemToCart({ userId, itemId }));
+  };
+
+  console.log(items)
 
   return (
     <>
@@ -30,15 +41,18 @@ const Items = () => {
                         <ul>
                           <li>{item.name}</li>
                           <li
-                            style={{ fontWeight: 'bold' }}
+                            style={{ fontWeight: "bold" }}
                           >{`$${item.price}`}</li>
                           <li>Number in cart: {`0`}</li>
                         </ul>
                       </div>
                     </Link>
 
-                    <div id="itemFooter">
-                      <Link to={`/items/${item.name}`}>Add to Cart</Link>
+                    <div
+                      id="itemFooter"
+                      onClick={() => handleAddToCart(item.id)}
+                    >
+                      <Link to={`/user/${userId}/cart`}>Add to Cart</Link>
                     </div>
                   </div>
                 </div>
@@ -54,164 +68,3 @@ const Items = () => {
 };
 
 export default Items;
-
-const ITEM_SEED_DATA = [
-  {
-    id: 1,
-    name: 'Cardamon Seed / Pod',
-    description:
-      'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.',
-    price: 51.58,
-    stock: 7,
-  },
-  {
-    id: 2,
-    name: 'Table Cloth 62x114 White',
-    description:
-      'Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius.',
-    price: 32.93,
-    stock: 91,
-  },
-  {
-    id: 3,
-    name: 'Juice - Apple, 500 Ml',
-    description:
-      'Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.',
-    price: 93.13,
-    stock: 90,
-  },
-  {
-    id: 4,
-    name: 'Lamb - Loin Chops',
-    description:
-      'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.',
-    price: 59.06,
-    stock: 23,
-  },
-  {
-    id: 5,
-    name: 'Asparagus - Green, Fresh',
-    description:
-      'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.',
-    price: 98.06,
-    stock: 8,
-  },
-  {
-    id: 6,
-    name: 'Cheese - Mix',
-    description:
-      'Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.',
-    price: 32.49,
-    stock: 62,
-  },
-  {
-    id: 7,
-    name: 'Honey - Comb',
-    description:
-      'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.',
-    price: 56.05,
-    stock: 71,
-  },
-  {
-    id: 8,
-    name: 'Apple - Macintosh',
-    description:
-      'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.',
-    price: 86.57,
-    stock: 40,
-  },
-  {
-    id: 9,
-    name: 'Wine - Sauvignon Blanc Oyster',
-    description:
-      'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.',
-    price: 38.13,
-    stock: 71,
-  },
-  {
-    id: 10,
-    name: 'Beef - Rib Eye Aaa',
-    description:
-      'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.',
-    price: 59.53,
-    stock: 40,
-  },
-  {
-    id: 11,
-    name: 'Salami - Genova',
-    description:
-      'Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.',
-    price: 42.18,
-    stock: 58,
-  },
-  {
-    id: 12,
-    name: 'Wine - Ej Gallo Sonoma',
-    description:
-      'Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.',
-    price: 79.93,
-    stock: 89,
-  },
-  {
-    id: 13,
-    name: 'Pastry - Baked Cinnamon Stick',
-    description:
-      'Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.',
-    price: 74.63,
-    stock: 100,
-  },
-  {
-    id: 14,
-    name: 'Bread - White, Unsliced',
-    description: 'Fusce consequat. Nulla nisl. Nunc nisl.',
-    price: 44.37,
-    stock: 81,
-  },
-  {
-    id: 15,
-    name: 'Soup - Knorr, Chicken Gumbo',
-    description:
-      'Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.',
-    price: 53.78,
-    stock: 7,
-  },
-  {
-    id: 16,
-    name: 'Salmon - Fillets',
-    description: 'Fusce consequat. Nulla nisl. Nunc nisl.',
-    price: 12.65,
-    stock: 60,
-  },
-  {
-    id: 17,
-    name: 'Oil - Canola',
-    description:
-      'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.',
-    price: 62.33,
-    stock: 77,
-  },
-  {
-    id: 18,
-    name: 'Pate Pans Yellow',
-    description:
-      'Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.',
-    price: 49.18,
-    stock: 92,
-  },
-  {
-    id: 19,
-    name: 'Cream - 10%',
-    description:
-      'Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.',
-    price: 63.31,
-    stock: 46,
-  },
-  {
-    id: 20,
-    name: 'Wine - Chablis J Moreau Et Fils',
-    description:
-      'Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.',
-    price: 11.77,
-    stock: 76,
-  },
-];

--- a/client/components/SingleItem.js
+++ b/client/components/SingleItem.js
@@ -1,18 +1,27 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { fetchSingleItem } from '../store/slices/items';
+import { fetchSingleItem, addItemToCart  } from '../store/slices/items';
 
 const SingleItem = () => {
   const dispatch = useDispatch();
   const { itemId } = useParams();
   const item = useSelector((state) => state.items.selectedItem);
+  const user = useSelector((state) => state.auth.user);
+  let userId = null;
+  if (user) {
+    userId = user.id;
+  }
 
   useEffect(() => {
     if (itemId) {
       dispatch(fetchSingleItem(itemId));
     }
   }, [itemId]);
+
+  const handleAddToCart = async (itemId) => {
+    await dispatch(addItemToCart({ userId, itemId }));
+  };
 
   if (!item.id) return null;
 
@@ -41,7 +50,7 @@ const SingleItem = () => {
             : 'Out of Stock'}
         </div>
         <p>Price: {`${item.price}$`}</p>
-        <button>Add to cart</button>
+        <button onClick={() => handleAddToCart(item.id)}>Add to cart</button>  {/*just need to be able to pass a qty as a second argument in handleAddToCart to fix only adding one to cart*/}
       </div>
     </div>
   );

--- a/client/store/slices/items.js
+++ b/client/store/slices/items.js
@@ -20,7 +20,7 @@ export const fetchSingleItem = createAsyncThunk(
   }
 );
 
-export const fetchItems = createAsyncThunk('getItems', async () => {
+export const fetchItems = createAsyncThunk('fetchItems', async () => {
   try {
     const { data } = await axios.get('/api/items');
     return data;
@@ -29,6 +29,21 @@ export const fetchItems = createAsyncThunk('getItems', async () => {
     return [];
   }
 });
+
+export const addItemToCart = createAsyncThunk(
+  "cart/addItem",
+  async ({ userId, itemId, quantity=1 }) => {
+    try {
+      const { data } = await axios.put(`/api/cart/${userId}/${itemId}`, {
+        itemId: itemId,
+        qty: quantity,
+      });
+      return data;
+    } catch (err) {
+      throw err.message;
+    }
+  }
+);
 
 export const updateItem = createAsyncThunk('updateItem', async (item) => {
   try {
@@ -70,7 +85,7 @@ const itemsSlice = createSlice({
       return { ...state, selectedItem: payload.item };
     });
     builder.addCase(fetchItems.fulfilled, (state, action) => {
-      return action.payload;
+      state.allItems = action.payload;
     });
     builder.addCase(updateItem.fulfilled, (state, { payload }) => {
       state.singleItem = payload;
@@ -78,13 +93,16 @@ const itemsSlice = createSlice({
     builder.addCase(deleteItem.fulfilled, (state, { payload }) => {
       state.allItems = state.allItems.filter((item) => item.id !== payload.id);
     });
+    builder.addCase(addItemToCart.fulfilled, (state) => {
+      state.error = null;
+    });
   },
 });
 
 export const { setError } = itemsSlice.actions;
 
 export const selectItems = (state) => {
-  return state.items;
+  return state.items.allItems;
 };
 
 export default itemsSlice.reducer;

--- a/server/api/routes/items.js
+++ b/server/api/routes/items.js
@@ -7,7 +7,7 @@ const {
 router.get('/', async (req, res, next) => {
   try {
     const items = await Item.findAll({});
-    res.json(items);
+    res.send(items);
   } catch (err) {
     next(err);
   }

--- a/server/db/models/ItemOrder.js
+++ b/server/db/models/ItemOrder.js
@@ -5,6 +5,7 @@ const Item_Order = db.define('Item_Order', {
   qty: {
     type: Sequelize.INTEGER,
     allowNull: false,
+    defaultValue: 1,
   },
 });
 


### PR DESCRIPTION
still need to be able to modify the quantity of what is added to cart in the single item page but you can now add to cart from the all item page and it will take you straight to the cart which just quickly needs to be refreshed to reflect the changes in the database.